### PR TITLE
send context independently of generating results, definite progress bar

### DIFF
--- a/.changeset/lovely-cities-judge.md
+++ b/.changeset/lovely-cities-judge.md
@@ -1,0 +1,5 @@
+---
+"caveql": minor
+---
+
+Add file bytes to ExecutionContext, rework query worker interface

--- a/lib/src/AsyncFlag.ts
+++ b/lib/src/AsyncFlag.ts
@@ -1,0 +1,33 @@
+export class AsyncFlag {
+  private resolve!: () => void;
+  private promise!: Promise<void>;
+  private flag = false;
+
+  constructor(flag = false) {
+    this.makePromise();
+    this.set(flag);
+  }
+
+  private makePromise() {
+    this.promise = new Promise((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+
+  public set(value: boolean) {
+    if (value === this.flag) {
+      return;
+    }
+    if (value) {
+      this.flag = true;
+      this.resolve();
+    } else {
+      this.flag = false;
+      this.makePromise();
+    }
+  }
+
+  public wait(): Promise<void> {
+    return this.promise;
+  }
+}

--- a/lib/src/compiler/compileQuery.ts
+++ b/lib/src/compiler/compileQuery.ts
@@ -74,10 +74,18 @@ export function compileQueryRaw(query: QueryAST): QuerySource {
 
 export type ExecutionContext = {
   recordsRead: number;
+  bytesRead: number;
+  bytesTotal: number | null;
 };
 
-export function createExecutionContext(): ExecutionContext {
+export function createExecutionContext({
+  bytesTotal = null,
+}: {
+  bytesTotal?: number | null;
+} = {}): ExecutionContext {
   return {
     recordsRead: 0,
+    bytesRead: 0,
+    bytesTotal,
   };
 }

--- a/lib/src/web-worker/message.ts
+++ b/lib/src/web-worker/message.ts
@@ -7,11 +7,13 @@ export type HostMessage =
       source: QuerySource;
       input: WorkerRecordsInput;
       context: ExecutionContext;
+      limit: number;
+      maxChunkSize: number;
+      maxIntervalMs: number;
     }
   | {
-      type: "getRecords";
-      maxCount: number;
-      maxTimeMs: number;
+      type: "loadMore";
+      limit: number;
     };
 
 export type WorkerRecordsInput =
@@ -32,6 +34,7 @@ export type WorkerMessage = {
   records: Record<string, unknown>[];
   context: ExecutionContext;
   done: boolean;
+  limited: boolean;
 };
 
 export function hostMessage(payload: HostMessage): HostMessage {

--- a/lib/src/web-worker/message.ts
+++ b/lib/src/web-worker/message.ts
@@ -22,17 +22,22 @@ export type WorkerRecordsInput =
       value:
         | Iterable<Record<string, unknown>>
         | AsyncIterable<Record<string, unknown>>;
+      approxCount: number | null;
     }
   | {
       type: "stream";
       stream: ReadableStream<Uint8Array>;
       format: SourceFormat;
+      sizeBytes: number | null;
     };
+
+export type Progress = "indeterminate" | number;
 
 export type WorkerMessage = {
   type: "sendRecords";
   records: Record<string, unknown>[];
   context: ExecutionContext;
+  progress: Progress;
   done: boolean;
   limited: boolean;
 };

--- a/lib/src/web-worker/queryWorker.ts
+++ b/lib/src/web-worker/queryWorker.ts
@@ -46,7 +46,7 @@ function startQuery(data: Extract<HostMessage, { type: "startQuery" }>) {
         return iter(run(data.input.value, data.context));
       }
       case "stream": {
-        return iter(run(readRecords(data.input), data.context));
+        return iter(run(readRecords(data.input, data.context), data.context));
       }
       default:
         impossible(data.input);
@@ -58,11 +58,13 @@ function startQuery(data: Extract<HostMessage, { type: "startQuery" }>) {
     if (!state) {
       throw new Error("Internal error: query not started");
     }
+    const { bytesRead, bytesTotal } = state.context;
     globalThis.postMessage(
       workerMessage({
         type: "sendRecords",
         records,
         context: state.context,
+        progress: bytesTotal != null ? bytesRead / bytesTotal : "indeterminate",
         done: state.done,
         limited,
       }),

--- a/webui/src/components/LoadingStrip.tsx
+++ b/webui/src/components/LoadingStrip.tsx
@@ -1,13 +1,34 @@
 import clsx from "clsx";
 
-export function LoadingStrip({ isLoading }: { isLoading: boolean }) {
+export function LoadingStrip({
+  isLoading,
+  progress,
+}: {
+  isLoading: boolean;
+  progress?: number | null;
+}) {
+  const isDeterminate = progress != null && progress >= 0;
+
   return (
     <div
       className={clsx(
-        "loading-strip-bg",
-        "h-1 bg-amber-200 delay-0 duration-200 transition-opacity opacity-0",
+        "h-1 delay-0 duration-200 transition-opacity opacity-0 overflow-hidden",
         isLoading && "opacity-100 delay-200",
+        isDeterminate && "bg-stone-300 dark:bg-stone-700",
       )}
-    />
+    >
+      <div
+        className="h-full w-full transition-[clip-path] duration-150"
+        style={
+          isDeterminate
+            ? {
+                clipPath: `inset(0 ${100 - Math.min(progress * 100, 100)}% 0 0)`,
+              }
+            : undefined
+        }
+      >
+        <div className="loading-strip-bg h-full w-full" />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
- Sending context is decoupled from generating results
- Simpler coordination between main+worker by limiting result count in the worker itself
- Estimate progress based on file size and measured bytes read